### PR TITLE
Release v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+v1_*.json
+v2_*.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/libs/HGVS-syntax-checker"]
+	path = src/libs/HGVS-syntax-checker
+	url = git@github.com:LOVDnl/HGVS-syntax-checker.git

--- a/README.md
+++ b/README.md
@@ -39,16 +39,26 @@ If you wish to run a copy of these APIs locally, all you need is to place the
  unexpected problems if we would update the API.**
 
 To allow easy further development of this API,
- we might change the way the API works or change the way the API returns data.
+ we may change the way the API works or change the way the API returns data.
 To make sure this doesn't harm your application,
  you can instruct the API to use a fixed version.
-To do so, you must include the APIs version in the URL.
-For instance, to always use version 1 of the API,
- even when version 2 is already released, use
- `/v1/checkHGVS` instead of `/checkHGVS`.
+To do so, you must include the API's version in the URL.
+For instance, to always use
+ [version 1](https://api.lovd.nl/v1/checkHGVS/NM_002225.3%3Ac.157C%3ET)
+ of the API, even with
+ [version 2](https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET)
+ now released, use `/v1/checkHGVS` instead of `/checkHGVS`.
 _When you're not supplying a version number in the URL,
  the API will automatically use the latest version._
+_This may cause your calls to fail if we release another update._
 Make a decision based on what works best for you in your situation.
+
+
+
+### Version 1 manual
+The manual specifically for version 1
+ [can be found here](https://github.com/LOVDnl/api.lovd.nl/blob/be43d94dc8703cf5224ed6a9ab918738ea24ba91/README.md#api-endpoints).
+Below is the updated manual for version 2.
 
 
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Use this method just to see if the API is alive or not.
 If it is, it will return an HTTP 200 status with the following output.
 ```json
 {
-  "version": 1,
-  "messages": [
-    "Hello!"
-  ],
-  "warnings": [],
-  "errors": [],
-  "data": []
+    "version": 2,
+    "messages": [
+        "Hello!"
+    ],
+    "warnings": [],
+    "errors": [],
+    "data": []
 }
 ```
 
@@ -95,42 +95,57 @@ It will return informative messages, warnings, and/or errors about the variant
 The JSON schema for the API output is encoded in the API itself and can be
  accessed by opening the URL `/checkHGVS/schema.json`.
 If you want to retrieve the schema for a certain version,
- use `/v1/checkHGVS/schema.json`.
-As an example, see https://api.lovd.nl/v1/checkHGVS/schema.json.
+ use `/v2/checkHGVS/schema.json`.
+As an example, see https://api.lovd.nl/v2/checkHGVS/schema.json.
 
 ##### Single variant input
 To submit a single variant description, e.g., `NM_002225.3:c.157C>T`, simply add
  it to the URL following the requirements for URL encoding:
 ```
-https://api.lovd.nl/v1/checkHGVS/NM_002225.3%3Ac.157C%3ET
+https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
 ```
 ```json
 {
-    "version": 1,
+    "version": 2,
     "messages": [
         "Successfully received 1 variant description.",
         "Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.",
-        "For sequence-level validation of DNA variants, please use https:\/\/variantvalidator.org."
+        "For sequence-level validation of DNA variants, please use https://variantvalidator.org."
     ],
     "warnings": [],
     "errors": [],
-    "data": {
-        "NM_002225.3:c.157C>T": {
-            "messages": {
-                "IOK": "This variant description is HGVS-compliant."
-            },
+    "data": [
+        {
+            "input": "NM_002225.3:c.157C>T",
+            "identified_as": "full_variant_DNA",
+            "identified_as_formatted": "full variant (DNA)",
+            "valid": true,
+            "messages": [],
             "warnings": [],
             "errors": [],
             "data": {
                 "position_start": 157,
                 "position_end": 157,
-                "type": "subst",
+                "position_start_intron": 0,
+                "position_end_intron": 0,
                 "range": false,
-                "suggested_correction": []
+                "type": ">"
+            },
+            "corrected_values": {
+                "NM_002225.3:c.157C>T": 1
             }
         }
-    },
-    "library_version": "2022-09-02"
+    ],
+    "versions": {
+        "library_version": "2025-02-14",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.1"
+            },
+            "output": "21.1.1"
+        }
+    }
 }
 ```
 
@@ -152,38 +167,52 @@ Such an update will not create a new API version, as the API version defines
  the behaviour of the API and its output.
 
 ```
-https://api.lovd.nl/v1/checkHGVS/NM_002225.3%3Ac.157delCinsT
+https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
 ```
 ```json
 {
-    "version": 1,
+    "version": 2,
     "messages": [
         "Successfully received 1 variant description.",
         "Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.",
-        "For sequence-level validation of DNA variants, please use https:\/\/variantvalidator.org."
+        "For sequence-level validation of DNA variants, please use https://variantvalidator.org."
     ],
     "warnings": [],
     "errors": [],
-    "data": {
-        "NM_002225.3:c.157delCinsT": {
+    "data": [
+        {
+            "input": "NM_002225.3:c.157delCinsT",
+            "identified_as": "full_variant_DNA",
+            "identified_as_formatted": "full variant (DNA)",
+            "valid": false,
             "messages": [],
             "warnings": {
-                "WWRONGTYPE": "A deletion-insertion of one base to one base should be described as a substitution. Please rewrite \"delCinsT\" to \"C>T\"."
+                "WWRONGTYPE": "Based on the given sequences, this deletion-insertion should be described as a substitution."
             },
             "errors": [],
             "data": {
                 "position_start": 157,
                 "position_end": 157,
-                "type": "delins",
+                "position_start_intron": 0,
+                "position_end_intron": 0,
                 "range": false,
-                "suggested_correction": {
-                    "value": "NM_002225.3:c.157C>T",
-                    "confidence": "high"
-                }
+                "type": "delins"
+            },
+            "corrected_values": {
+                "NM_002225.3:c.157C>T": 1
             }
         }
-    },
-    "library_version": "2022-09-02"
+    ],
+    "versions": {
+        "library_version": "2025-02-14",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.1"
+            },
+            "output": "21.1.1"
+        }
+    }
 }
 ```
 
@@ -226,22 +255,25 @@ We decided on this structure since lots of possible single character separators
 E.g., the forward slash is used to indicate mosaicism and chimerism, and the
  pipe is used for non-sequence related changes such as loss of methylation.
 ```
-https://api.lovd.nl/v1/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
+https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
 ```
 ```json
 {
-    "version": 1,
+    "version": 2,
     "messages": [
         "Successfully received 2 variant descriptions.",
         "Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.",
-        "For sequence-level validation of DNA variants, please use https:\/\/variantvalidator.org."
+        "For sequence-level validation of DNA variants, please use https://variantvalidator.org."
     ],
     "warnings": [],
     "errors": [],
-    "data": {
-        "c.157C>T": {
+    "data": [
+        {
+            "input": "c.157C>T",
+            "identified_as": "variant_DNA",
+            "identified_as_formatted": "variant (DNA)",
+            "valid": true,
             "messages": {
-                "IOK": "This variant description is HGVS-compliant.",
                 "IREFSEQMISSING": "Please note that your variant description is missing a reference sequence. Although this is not necessary for our syntax check, a variant description does need a reference sequence to be fully informative and HGVS-compliant."
             },
             "warnings": [],
@@ -249,14 +281,21 @@ https://api.lovd.nl/v1/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
             "data": {
                 "position_start": 157,
                 "position_end": 157,
-                "type": "subst",
+                "position_start_intron": 0,
+                "position_end_intron": 0,
                 "range": false,
-                "suggested_correction": []
+                "type": ">"
+            },
+            "corrected_values": {
+                "c.157C>T": 1
             }
         },
-        "g.40699840C>T": {
+        {
+            "input": "g.40699840C>T",
+            "identified_as": "variant_DNA",
+            "identified_as_formatted": "variant (DNA)",
+            "valid": true,
             "messages": {
-                "IOK": "This variant description is HGVS-compliant.",
                 "IREFSEQMISSING": "Please note that your variant description is missing a reference sequence. Although this is not necessary for our syntax check, a variant description does need a reference sequence to be fully informative and HGVS-compliant."
             },
             "warnings": [],
@@ -264,13 +303,24 @@ https://api.lovd.nl/v1/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
             "data": {
                 "position_start": 40699840,
                 "position_end": 40699840,
-                "type": "subst",
                 "range": false,
-                "suggested_correction": []
+                "type": ">"
+            },
+            "corrected_values": {
+                "g.40699840C>T": 1
             }
         }
-    },
-    "library_version": "2022-09-02"
+    ],
+    "versions": {
+        "library_version": "2025-02-14",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.1"
+            },
+            "output": "21.1.1"
+        }
+    }
 }
 ```
 If the same variant description has been submitted more than once in the same

--- a/README.md
+++ b/README.md
@@ -150,21 +150,24 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
 ```
 
 Note that the first `messages`, `warnings`, and `errors` arrays describe the
- request as a whole, while those whithin the `data` object are specific for the
+ request as a whole, while those within the `data` object are specific for the
  given variant.
 Errors are, in general, non-recoverable.
 Warnings are, in general, recoverable and easily repairable.
 Messages are simply for your information.
 Due to limitations of our implementation of PHP's `json_encode()`, these objects
  will be arrays when empty.
-This applies as well to the `suggested_correction` object.
 This may be corrected in a later version of the API.
 
+The `versions` object collects all relevant versions related to the library that
+ powers this API.
 The `library_version` shows the date the internal libraries that interpret
  variant descriptions and provide feedback and possible corrections, were
  updated.
 Such an update will not create a new API version, as the API version defines
  the behaviour of the API and its output.
+The `HGVS_nomenclature_versions` object shows supported HGVS nomenclature
+ versions for input (minimum, maximum) and for output.
 
 ```
 https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
@@ -233,9 +236,10 @@ Note also that errors and warnings exist with similar codes, e.g., `EWRONGTYPE`
 
 When requesting a variant that contains incorrect syntax, the API will attempt
  to repair your description.
-If this results in a suggested correction, this suggestion is always provided
- with a confidence of either `high`, `medium`, or `low`, indicating how sure the
- library is that its suggestion describes the variant you meant to describe.
+If this results in one or more suggested corrections,
+ these suggestions are always provided with a confidence score between
+ near-zero and one, indicating how sure the library is that its suggestion
+ represents the variant you meant to describe.
 
 ##### Multiple variant input
 To submit multiple variant descriptions in one request, present them as a
@@ -323,8 +327,5 @@ https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
     }
 }
 ```
-If the same variant description has been submitted more than once in the same
- request, it will be presented in the output only once since the descriptions
- are used as keys.
 
 More information on the output can be found under "[Single variant input](#single-variant-input)".

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -613,6 +613,27 @@ class LOVD_API_checkHGVS
             ),
         );
 
+        // OK, actually, "data" is not completely the same.
+        $aReturn['properties']['data']['items']['properties']['data']['properties']['type']['enum'] = array(
+            '=',
+            '>',
+            '?',
+            '^',
+            ';',
+            '0',
+            'chimeric',
+            'cnv',
+            'del',
+            'delins',
+            'dup',
+            'ins',
+            'inv',
+            'met',
+            'mosaic',
+            'repeat',
+            'sup',
+        );
+
         // Remove "suggested_correction".
         unset($aReturn['properties']['data']['items']['properties']['data']['properties']['suggested_correction']);
         // Also "type" isn't required anymore, so just rebuild the "required" array.

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -322,7 +322,6 @@ class LOVD_API_checkHGVS
 
 
 
-    // NOTE: Don't just change this function's name, it's called through call_user_func().
     public function v1_getJSONSchema ()
     {
         // Return the JSON Schema for the v1 checkHGVS response format.
@@ -339,7 +338,7 @@ class LOVD_API_checkHGVS
                 'version' => array(
                     'description' => 'The version of the API specification.',
                     'type' => 'integer',
-                    'minimum' => 1,
+                    'const' => 1,
                 ),
                 'messages' => array(
                     'description' => 'A list of messages, simply providing information and not indicating any kind of error.',
@@ -542,6 +541,23 @@ class LOVD_API_checkHGVS
                 'library_version',
             ),
         );
+    }
+
+
+
+
+
+    public function v2_getJSONSchema ()
+    {
+        // Return the JSON Schema for the v2 checkHGVS response format.
+        // Takes the basics from the previous version, then makes changes.
+
+        $aReturn = $this->v1_getJSONSchema();
+
+        // Fix the version.
+        $aReturn['properties']['version']['const'] = 2;
+
+        return $aReturn;
     }
 }
 ?>

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2025-02-17   // When modified, also change the library_version.
+ * Modified    : 2025-02-18
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -643,6 +643,49 @@ class LOVD_API_checkHGVS
             'range',
         );
 
+        // Replace "library_version" with "versions".
+        unset($aReturn['properties']['library_version']);
+        $aReturn['properties']['versions'] = array(
+            'description' => 'All relevant versions related to the library that powers this API.',
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => array(
+                'library_version' => array(
+                    'description' => 'The date that the library that powers this API, has been updated.',
+                    'type' => 'string',
+                    'pattern' => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+                ),
+                'HGVS_nomenclature_versions' => array(
+                    'description' => 'The HGVS nomenclature versions supported by this library.',
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => array(
+                        'input' => array(
+                            'description' => 'The minimum and maximum HGVS nomenclature versions supported by this library as input.',
+                            'type' => 'object',
+                            'additionalProperties' => false,
+                            'properties' => array(
+                                'minimum' => array(
+                                    'type' => 'string',
+                                    'pattern' => '^[0-9]{2}\.[0-9]{1,2}(\.[0-9]{1,2})?$',
+                                ),
+                                'maximum' => array(
+                                    'type' => 'string',
+                                    'pattern' => '^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}$',
+                                ),
+                            ),
+                        ),
+                        'output' => array(
+                            'description' => 'The HGVS nomenclature version of the output created by this library.',
+                            'type' => 'string',
+                            'pattern' => '^[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}$',
+                        ),
+                    ),
+                ),
+            ),
+        );
+        $aReturn['required'][4] = 'versions';
+
         return $aReturn;
     }
 }

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -116,6 +116,19 @@ class LOVD_API_checkHGVS
 
 
 
+        // Check the current version and run that method.
+        $sMethod = 'v' . $this->API->nVersion . '_checkHGVS';
+        return call_user_func(array($this, $sMethod), $aInput);
+    }
+
+
+
+
+
+    public function v1_checkHGVS ($aInput)
+    {
+        // Run the validations, using the old lovd_getVariantInfo() and lovd_fixHGVS() approach.
+
         // For non-unique input, throw a warning, but continue.
         $aInputUnique = array_unique($aInput, SORT_STRING);
         if ($aInput != $aInputUnique) {

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2024-05-31   // When modified, also change the library_version.
+ * Modified    : 2025-02-17   // When modified, also change the library_version.
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -53,7 +53,6 @@ class LOVD_API_checkHGVS
             return false;
         }
         $this->API = $oAPI;
-        $this->API->aResponse['library_version'] = '2024-05-31';
 
         return true;
     }
@@ -246,6 +245,7 @@ class LOVD_API_checkHGVS
 
             $this->API->aResponse['data'][$sVariant] = $aResponse;
         }
+        $this->API->aResponse['library_version'] = '2024-05-31';
         return true;
     }
 

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -7,7 +7,7 @@
  * Modified    : 2025-02-18
  * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -557,6 +557,71 @@ class LOVD_API_checkHGVS
         // Fix the version.
         $aReturn['properties']['version']['const'] = 2;
 
+        // Fix the data specs.
+        $aReturn['properties']['data'] = array(
+            'description' => 'The data that is the result of the API request. This is empty if a problem occurred while handling the request.',
+            'type' => 'array',
+            'items' => array(
+                'type' => 'object',
+                'additionalProperties' => false,
+                'properties' => array(
+                    'input' => array(
+                        'description' => 'The given input.',
+                        'type' => 'string',
+                    ),
+                    'identified_as' => array(
+                        'description' => 'A short description of what the library identified the input as. This field is meant to be parsed, if needed.',
+                        'type' => 'string',
+                    ),
+                    'identified_as_formatted' => array(
+                        'description' => 'A formatted version of the "identified as" field. This field is meant to be displayed to the user, if needed.',
+                        'type' => 'string',
+                    ),
+                    'valid' => array(
+                        'description' => 'Whether the input was considered to be a valid variant description.',
+                        'type' => 'boolean',
+                    ),
+                    'messages' => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['messages'],
+                    'warnings' => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['warnings'],
+                    'errors'   => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['errors'],
+                    'data'     => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['data'],
+                    'corrected_values' => array(
+                        'description' => 'One or more corrected variant descriptions, given with a confidence score. The given corrections are not necessarily different from the input.',
+                        'type' => 'object',
+                        'additionalProperties' => false,
+                        'patternProperties' => array(
+                            '^.+$' => array(
+                                'description' => 'The confidence score for this correction, ranging from near zero to 100%.',
+                                'type' => 'number',
+                                'exclusiveMinimum' => 0,
+                                'maximum' => 1,
+                            ),
+                        ),
+                    ),
+                ),
+                'required' => array(
+                    'input',
+                    'identified_as',
+                    'identified_as_formatted',
+                    'valid',
+                    'messages',
+                    'warnings',
+                    'errors',
+                    'data',
+                    'corrected_values',
+                ),
+            ),
+        );
+
+        // Remove "suggested_correction".
+        unset($aReturn['properties']['data']['items']['properties']['data']['properties']['suggested_correction']);
+        // Also "type" isn't required anymore, so just rebuild the "required" array.
+        $aReturn['properties']['data']['items']['properties']['data']['required'] = array(
+            'position_start',
+            'position_end',
+            'range',
+        );
+
         return $aReturn;
     }
 }

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -279,6 +279,18 @@ class LOVD_API_checkHGVS
 
         require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
         $this->API->aResponse['versions'] = HGVS::getVersions();
+
+        // v1 used to have a check here for unique input, but since we format the output differently, we don't care.
+        $nInput = count($aInput);
+        $this->API->aResponse['messages'][] = "Successfully received $nInput variant description" . ($nInput == 1? "." : "s.");
+        $this->API->aResponse['messages'][] = 'Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.';
+        $this->API->aResponse['messages'][] = 'For sequence-level validation of DNA variants, please use https://variantvalidator.org.';
+
+        // Now actually handle the request.
+        foreach ($aInput as $sVariant) {
+            $aResponse = HGVS::checkVariant($sVariant)->allowMissingReferenceSequence()->getInfo();
+            $this->API->aResponse['data'][] = $aResponse;
+        }
         return true;
     }
 

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -266,6 +266,26 @@ class LOVD_API_checkHGVS
 
 
 
+    public function v2_checkHGVS ($aInput)
+    {
+        // Run the validations, using the new HGVS class approach.
+        if (!file_exists(ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php')) {
+            // This API requires the HGVS.php class file from https://github.com/LOVDnl/HGVS-syntax-checker.
+            // If not found, double-check if you ran `git submodule init && git submodule update`.
+            // This repository will not duplicate the code.
+            $this->API->aResponse['errors'][] = 'Could not load the HGVS library.';
+            return false;
+        }
+
+        require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
+        $this->API->aResponse['versions'] = HGVS::getVersions();
+        return true;
+    }
+
+
+
+
+
     // NOTE: Don't just change this function's name, it's called through call_user_func().
     public function v1_getJSONSchema ()
     {

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -214,7 +214,7 @@ class LOVD_API_OpenAPISpecs
                             'content' => array(
                                 'application/json' => array(
                                     'example' => array(
-                                        'version' => 1,
+                                        'version' => $this->API->nVersion,
                                         'messages' => array(
                                             'Hello!',
                                         ),
@@ -246,7 +246,7 @@ class LOVD_API_OpenAPISpecs
                             '$ref' => 'checkHGVS/schema.json',
                         ),
                         'example' => array(
-                            'version' => 1,
+                            'version' => $this->API->nVersion,
                             'messages' => array(
                                 'Successfully received 1 variant description.',
                                 'Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.',
@@ -283,7 +283,7 @@ class LOVD_API_OpenAPISpecs
                             '$ref' => 'checkHGVS/schema.json',
                         ),
                         'example' => array(
-                            'version' => 1,
+                            'version' => $this->API->nVersion,
                             'messages' => array(),
                             'warnings' => array(),
                             'errors' => array(
@@ -303,7 +303,7 @@ class LOVD_API_OpenAPISpecs
                             '$ref' => 'checkHGVS/schema.json',
                         ),
                         'example' => array(
-                            'version' => 1,
+                            'version' => $this->API->nVersion,
                             'messages' => array(),
                             'warnings' => array(),
                             'errors' => array(

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-24
- * Modified    : 2022-11-29         // When modified, also change info->version.
+ * Modified    : 2025-02-19         // When modified, also change info->version.
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -85,18 +85,11 @@ class LOVD_API_OpenAPISpecs
                     'name' => 'GNU General Public License v3.0',
                     'url' => 'https://github.com/LOVDnl/api.lovd.nl/raw/main/LICENSE',
                 ),
-                'version' => '2025-02-18',
             ),
             'servers' => array(
                 array(
-                    'url' => 'https://api.lovd.nl/{version}',
-                    'description' => 'Public LOVD APIs, production server.',
-                    'variables' => array(
-                        'version' => array(
-                            'enum' => $aVersions,
-                            'default' => 'v' . $this->API->nVersion,
-                        ),
-                    ),
+                    'url' => lovd_getInstallURL() . 'v' . $this->API->nVersion,
+                    'description' => 'Public LOVD APIs, production server, API v' . $this->API->nVersion . '.',
                 ),
             ),
             'paths' => array(), // NOTE: Will be filled in later by v#_getOpenAPISpecs().
@@ -143,6 +136,9 @@ class LOVD_API_OpenAPISpecs
     {
         // Fill in the v1-specific data.
         $aResponse = $this->API->aResponse;
+
+        // Add the version (date).
+        $aResponse['info']['version'] = '2022-11-29';
 
         // Provide the available paths.
         $aResponse['paths'] = array(
@@ -329,6 +325,9 @@ class LOVD_API_OpenAPISpecs
         // Fill in the v2-specific data.
         // Takes the basics from the previous version, then makes changes.
         $aResponse = $this->v1_getOpenAPISpecs();
+
+        // Add the version (date).
+        $aResponse['info']['version'] = '2025-02-19';
 
         // Provide the available responses, they are different from v1.
         // First, some general changes.

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -138,7 +138,7 @@ class LOVD_API_OpenAPISpecs
         $aResponse = $this->API->aResponse;
 
         // Add the version (date).
-        $aResponse['info']['version'] = '2022-11-29';
+        $aResponse['info']['version'] = '2022-11-29'; // Copied in swagger-initializer.js.
 
         // Provide the available paths.
         $aResponse['paths'] = array(
@@ -327,7 +327,7 @@ class LOVD_API_OpenAPISpecs
         $aResponse = $this->v1_getOpenAPISpecs();
 
         // Add the version (date).
-        $aResponse['info']['version'] = '2025-02-19';
+        $aResponse['info']['version'] = '2025-02-19'; // Copied in swagger-initializer.js.
 
         // Provide the available responses, they are different from v1.
         // First, some general changes.

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -7,7 +7,7 @@
  * Modified    : 2025-02-19         // When modified, also change info->version.
  * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -327,7 +327,49 @@ class LOVD_API_OpenAPISpecs
     public function v2_getOpenAPISpecs ()
     {
         // Fill in the v2-specific data.
+        // Takes the basics from the previous version, then makes changes.
         $aResponse = $this->v1_getOpenAPISpecs();
+
+        // Provide the available responses, they are different from v1.
+        // First, some general changes.
+        unset($aResponse['components']['responses']['200_checkHGVS']['content']['application/json']['example']['library_version']);
+        unset($aResponse['components']['responses']['4XX_checkHGVS']['content']['application/json']['example']['library_version']);
+        unset($aResponse['components']['responses']['500_checkHGVS']['content']['application/json']['example']['library_version']);
+
+        // Update the 200 OK output.
+        $aResponse['components']['responses']['200_checkHGVS']['content']['application/json']['example']['data'] = array(
+            array(
+                'input' => 'NM_002225.3:c.157C>T',
+                'identified_as' => 'full_variant_DNA',
+                'identified_as_formatted' => 'full variant (DNA)',
+                'valid' => true,
+                'messages' => array(),
+                'warnings' => array(),
+                'errors' => array(),
+                'data' => array(
+                    'position_start' => 157,
+                    'position_end' => 157,
+                    'position_start_intron' => 0,
+                    'position_end_intron' => 0,
+                    'range' => false,
+                    'type' => ">"
+                ),
+                'corrected_values' => array(
+                    'NM_002225.3:c.157C>T' => 1
+                )
+            )
+        );
+        $aResponse['components']['responses']['200_checkHGVS']['content']['application/json']['example']['versions'] = array(
+            'library_version' => '2025-02-14',
+            'HGVS_nomenclature_versions' => array(
+                'input' => array(
+                    'minimum' => '15.11',
+                    'maximum' => '21.1.1'
+                ),
+                'output' => '21.1.1'
+            ),
+        );
+
         return $aResponse;
     }
 }

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -139,7 +139,6 @@ class LOVD_API_OpenAPISpecs
 
 
 
-    // NOTE: Don't just change this function's name, it's called through call_user_func() and get_class_methods().
     public function v1_getOpenAPISpecs ()
     {
         // Fill in the v1-specific data.
@@ -318,6 +317,17 @@ class LOVD_API_OpenAPISpecs
             ),
         );
 
+        return $aResponse;
+    }
+
+
+
+
+
+    public function v2_getOpenAPISpecs ()
+    {
+        // Fill in the v2-specific data.
+        $aResponse = $this->v1_getOpenAPISpecs();
         return $aResponse;
     }
 }

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -85,7 +85,7 @@ class LOVD_API_OpenAPISpecs
                     'name' => 'GNU General Public License v3.0',
                     'url' => 'https://github.com/LOVDnl/api.lovd.nl/raw/main/LICENSE',
                 ),
-                'version' => '2022-11-29',
+                'version' => '2025-02-18',
             ),
             'servers' => array(
                 array(
@@ -99,87 +99,9 @@ class LOVD_API_OpenAPISpecs
                     ),
                 ),
             ),
-            'paths' => array(), // To be filled in later.
+            'paths' => array(), // NOTE: Will be filled in later by v#_getOpenAPISpecs().
             'components' => array(
-                'responses' => array(
-                    '200_checkHGVS' => array(
-                        'description' => 'A result of a successfully processed variant or list of variants. This does not mean that the input variant(s) are using valid nomenclature.',
-                        'content' => array(
-                            'application/json' => array(
-                                'schema' => array(
-                                    '$ref' => 'checkHGVS/schema.json',
-                                ),
-                                'example' => array(
-                                    'version' => 1,
-                                    'messages' => array(
-                                        'Successfully received 1 variant description.',
-                                        'Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.',
-                                        'For sequence-level validation of DNA variants, please use https:\/\/variantvalidator.org.'
-                                    ),
-                                    'warnings' => array(),
-                                    'errors' => array(),
-                                    'data' => array(
-                                        'NM_002225.3:c.157C>T' => array(
-                                            'messages' => array(
-                                                'IOK' => 'This variant description is HGVS-compliant.'
-                                            ),
-                                            'warnings' => array(),
-                                            'errors' => array(),
-                                            'data' => array(
-                                                'position_start' => 157,
-                                                'position_end' => 157,
-                                                'type' => 'subst',
-                                                'range' => false,
-                                                'suggested_correction' => array()
-                                            )
-                                        )
-                                    ),
-                                    'library_version' => '2022-08-24'
-                                ),
-                            ),
-                        ),
-                    ),
-                    '4XX_checkHGVS' => array(
-                        'description' => 'A result of a processing error. The API has not been queried properly, and the data could not be processed.',
-                        'content' => array(
-                            'application/json' => array(
-                                'schema' => array(
-                                    '$ref' => 'checkHGVS/schema.json',
-                                ),
-                                'example' => array(
-                                    'version' => 1,
-                                    'messages' => array(),
-                                    'warnings' => array(),
-                                    'errors' => array(
-                                        'Could not parse the given request. Did you submit a variant?'
-                                    ),
-                                    'data' => array(),
-                                    'library_version' => '2022-08-24'
-                                ),
-                            ),
-                        ),
-                    ),
-                    '500_checkHGVS' => array(
-                        'description' => 'A result of an internal error. The library could somehow not handle the request.',
-                        'content' => array(
-                            'application/json' => array(
-                                'schema' => array(
-                                    '$ref' => 'checkHGVS/schema.json',
-                                ),
-                                'example' => array(
-                                    'version' => 1,
-                                    'messages' => array(),
-                                    'warnings' => array(),
-                                    'errors' => array(
-                                        'Request not handled well by any handler.'
-                                    ),
-                                    'data' => array(),
-                                    'library_version' => '2022-08-24'
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
+                'responses' => array(), // NOTE: Will be filled in later by v#_getOpenAPISpecs().
             ),
             'externalDocs' => array(
                 'description' => 'More documentation can be found on our Github page.',
@@ -220,7 +142,10 @@ class LOVD_API_OpenAPISpecs
     // NOTE: Don't just change this function's name, it's called through call_user_func() and get_class_methods().
     public function v1_getOpenAPISpecs ()
     {
+        // Fill in the v1-specific data.
         $aResponse = $this->API->aResponse;
+
+        // Provide the available paths.
         $aResponse['paths'] = array(
             '/checkHGVS/{variant}' => array(
                 'get' => array(
@@ -306,6 +231,87 @@ class LOVD_API_OpenAPISpecs
                         ),
                         '500' => array(
                             'description' => 'A result of an internal error.',
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        // Provide the available responses.
+        $aResponse['components']['responses'] = array(
+            '200_checkHGVS' => array(
+                'description' => 'A result of a successfully processed variant or list of variants. This does not mean that the input variant(s) are using valid nomenclature.',
+                'content' => array(
+                    'application/json' => array(
+                        'schema' => array(
+                            '$ref' => 'checkHGVS/schema.json',
+                        ),
+                        'example' => array(
+                            'version' => 1,
+                            'messages' => array(
+                                'Successfully received 1 variant description.',
+                                'Note that this API does not validate variants on the sequence level, but only checks if the variant description follows the HGVS nomenclature rules.',
+                                'For sequence-level validation of DNA variants, please use https:\/\/variantvalidator.org.'
+                            ),
+                            'warnings' => array(),
+                            'errors' => array(),
+                            'data' => array(
+                                'NM_002225.3:c.157C>T' => array(
+                                    'messages' => array(
+                                        'IOK' => 'This variant description is HGVS-compliant.'
+                                    ),
+                                    'warnings' => array(),
+                                    'errors' => array(),
+                                    'data' => array(
+                                        'position_start' => 157,
+                                        'position_end' => 157,
+                                        'type' => 'subst',
+                                        'range' => false,
+                                        'suggested_correction' => array()
+                                    )
+                                )
+                            ),
+                            'library_version' => '2022-08-24'
+                        ),
+                    ),
+                ),
+            ),
+            '4XX_checkHGVS' => array(
+                'description' => 'A result of a processing error. The API has not been queried properly, and the data could not be processed.',
+                'content' => array(
+                    'application/json' => array(
+                        'schema' => array(
+                            '$ref' => 'checkHGVS/schema.json',
+                        ),
+                        'example' => array(
+                            'version' => 1,
+                            'messages' => array(),
+                            'warnings' => array(),
+                            'errors' => array(
+                                'Could not parse the given request. Did you submit a variant?'
+                            ),
+                            'data' => array(),
+                            'library_version' => '2022-08-24'
+                        ),
+                    ),
+                ),
+            ),
+            '500_checkHGVS' => array(
+                'description' => 'A result of an internal error. The library could somehow not handle the request.',
+                'content' => array(
+                    'application/json' => array(
+                        'schema' => array(
+                            '$ref' => 'checkHGVS/schema.json',
+                        ),
+                        'example' => array(
+                            'version' => 1,
+                            'messages' => array(),
+                            'warnings' => array(),
+                            'errors' => array(
+                                'Request not handled well by any handler.'
+                            ),
+                            'data' => array(),
+                            'library_version' => '2022-08-24'
                         ),
                     ),
                 ),

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -8,7 +8,7 @@
  * Modified    : 2025-02-18
  * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -5,7 +5,7 @@
  * Adapted from /src/class/api.php in the LOVD3 project.
  *
  * Created     : 2022-08-08
- * Modified    : 2024-05-07
+ * Modified    : 2025-02-18
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -41,7 +41,7 @@ class LOVD_API
     // This class defines the LOVD API object, handling URL parsing and general
     //  handling of headers.
 
-    public $nVersion = 1;     // The API version. 0 for the LOVD2-style API. Higher versions are for the LOVD3-style REST API.
+    public $nVersion = 2;     // The API version. 0 for the LOVD2-style API. Higher versions are for the LOVD3-style REST API.
     public $sMethod = '';     // The used method (GET, POST, PUT, DELETE).
     public $sResource = '';   // The requested resource.
     public $nID = '';         // The ID of the requested resource.

--- a/src/swagger/swagger-initializer.js
+++ b/src/swagger/swagger-initializer.js
@@ -1,9 +1,15 @@
 window.onload = function() {
   //<editor-fold desc="Changeable Configuration Block">
 
+  if (location.hostname == "localhost") {
+    var path = "localhost/git/api.lovd.nl/src";
+  } else {
+    var path = "api.lovd.nl";
+  }
+
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: window.location.protocol + "//api.lovd.nl/v1/swagger.json",
+    url: window.location.protocol + "//" + path + "/v1/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/src/swagger/swagger-initializer.js
+++ b/src/swagger/swagger-initializer.js
@@ -9,7 +9,17 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: window.location.protocol + "//" + path + "/v1/swagger.json",
+    urls: [
+        {
+          name: "v1 (2022-11-29)",
+          url: window.location.protocol + "//" + path + "/v1/swagger.json"
+        },
+        {
+          name: "v2 (2025-02-19)",
+          url: window.location.protocol + "//" + path + "/v2/swagger.json"
+        }
+    ],
+    "urls.primaryName": "v2 (2025-02-19)",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/tests/checkHGVS.php
+++ b/tests/checkHGVS.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-16
- * Modified    : 2022-11-29
+ * Modified    : 2025-02-19
  * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -283,7 +283,7 @@ $aTests = array(
         // lovd_getVariantInfo()'s insertion-related tests that are fixable.
         'g.1_2ins(50)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.'
+                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins50_60") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[50]")?'
             ),
             'data' => array(
                 'position_start' => 1,
@@ -423,7 +423,7 @@ $aTests = array(
         'g.123conNC_000001.10:100_200' => array(
             'warnings' => array(
                 'WWRONGTYPE' => 'A conversion should be described as a deletion-insertion. Please rewrite "con" to "delins".',
-                'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines.',
+                'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC_000001.10:100_200".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -438,7 +438,7 @@ $aTests = array(
         ),
         'g.1_5delins20_10' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "delins" does not follow HGVS guidelines.',
+                'WSUFFIXFORMAT' => 'The part after "delins" does not follow HGVS guidelines. The positions are not given in the correct order. Please verify your description and try again.',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -828,7 +828,7 @@ $aTests = array(
         // lovd_getVariantInfo()'s tests for fixable challenging insertions.
         'g.1_2ins(5_10)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins5_10") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[(5_10)]")?',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -843,7 +843,7 @@ $aTests = array(
         ),
         'g.1_2ins[A]' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Only use square brackets for complex insertions.',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -858,7 +858,7 @@ $aTests = array(
         ),
         'g.1_2insNC123456.1:g.1_10' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC123456.1:g.1_10".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -890,7 +890,7 @@ $aTests = array(
         ),
         'g.(1_100)del50' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "50" to "N[50]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "50" to "N[50]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -905,7 +905,7 @@ $aTests = array(
         ),
         'g.(1_100)del(30)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -920,7 +920,7 @@ $aTests = array(
         ),
         'g.(1_100)del(30_30)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30_30)" to "N[30]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30_30)" to "N[30]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -935,7 +935,7 @@ $aTests = array(
         ),
         'g.(1_100)del(30_50)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30_50)" to "N[(30_50)]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30_50)" to "N[(30_50)]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -950,7 +950,7 @@ $aTests = array(
         ),
         'g.(1_100)del(50_30)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(50_30)" to "N[(30_50)]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(50_30)" to "N[(30_50)]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -965,7 +965,7 @@ $aTests = array(
         ),
         'g.(1_100)delN[30_50]' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "N[30_50]" to "N[(30_50)]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "N[30_50]" to "N[(30_50)]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -980,7 +980,7 @@ $aTests = array(
         ),
         'g.(100_200)_(400_500)del300' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "300" to "N[300]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "300" to "N[300]".',
             ),
             'data' => array(
                 'position_start' => 200,
@@ -995,7 +995,7 @@ $aTests = array(
         ),
         'g.(1_200)_(400_500)del(300)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(300)" to "N[300]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(300)" to "N[300]".',
             ),
             'data' => array(
                 'position_start' => 200,
@@ -1010,7 +1010,7 @@ $aTests = array(
         ),
         'g.(1_100)inv(30)' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                'WSUFFIXFORMAT' => 'The part after "inv" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
             ),
             'data' => array(
                 'position_start' => 1,
@@ -1103,7 +1103,7 @@ $aTests = array(
         // lovd_getVariantInfo()'s tests for all other errors or problems.
         'G.123dup' => array(
             'warnings' => array(
-                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters.',
+                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "G." to "g.".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1118,7 +1118,7 @@ $aTests = array(
         ),
         'g.123DUP' => array(
             'warnings' => array(
-                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters.',
+                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "DUP" to "dup".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1134,6 +1134,7 @@ $aTests = array(
         'g.123_130delgagagatt' => array(
             'warnings' => array(
                 'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delgagagatt" to "delGAGAGATT".',
+                'WSUFFIXGIVEN' => 'Nothing should follow "del".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1148,8 +1149,27 @@ $aTests = array(
         ),
         'g.123_130delgagagauu' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "delgagagauu" to "delGAGAGATT".',
-                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
+                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delgagagauu" to "delGAGAGAUU".',
+                'WSUFFIXGIVEN' => 'Nothing should follow "del".',
+            ),
+            'errors' => array(
+                'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+            ),
+            'data' => array(
+                'position_start' => 123,
+                'position_end' => 130,
+                'type' => 'del',
+                'range' => true,
+                'suggested_correction' => array(
+                    'value' => 'g.123_130del',
+                    'confidence' => 'low',
+                ),
+            )
+        ),
+        'g.123_130deln[8]' => array(
+            'warnings' => array(
+                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "deln[8]" to "delN[8]".',
+                'WSUFFIXGIVEN' => 'Nothing should follow "del".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1162,25 +1182,12 @@ $aTests = array(
                 ),
             )
         ),
-        'g.123_130deln[8]' => array(
-            'warnings' => array(
-                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "deln[8]" to "delN[8]".',
-            ),
-            'data' => array(
-                'position_start' => 123,
-                'position_end' => 130,
-                'type' => 'del',
-                'range' => true,
-                'suggested_correction' => array(
-                    'value' => 'g.123_130del',
-                    'confidence' => 'high',
-                ),
-            )
-        ),
         'g.123delinsgagagauu' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => // Adding a WWRONGCASE here is difficult; the code handling insertions is too complex and we'd need to then fix lovd_fixHGVS() again also.
-                    'The part after "delins" does not follow HGVS guidelines.', // Idem for the suggestion how to fix it. It's too complex right now and lovd_fixHGVS() easily handles it anyway.
+                'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delinsgagagauu" to "delinsGAGAGAUU".',
+            ),
+            'errors' => array(
+                'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1189,7 +1196,7 @@ $aTests = array(
                 'range' => false,
                 'suggested_correction' => array(
                     'value' => 'g.123delinsGAGAGATT',
-                    'confidence' => 'medium',
+                    'confidence' => 'low',
                 ),
             )
         ),
@@ -1214,7 +1221,10 @@ $aTests = array(
             'warnings' => array(
                 'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
                 'WWRONGTYPE' =>
-                    'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "delainsu" to "A>T".',
+                    'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "delainsu" to "A>U".',
+            ),
+            'errors' => array(
+                'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
             ),
             'data' => array(
                 'position_start' => 123,
@@ -1223,7 +1233,7 @@ $aTests = array(
                 'range' => false,
                 'suggested_correction' => array(
                     'value' => 'g.123A>T',
-                    'confidence' => 'high',
+                    'confidence' => 'low',
                 ),
             )
         ),
@@ -1261,7 +1271,7 @@ $aTests = array(
         // API-specific test; do we suggest something anyway, when a EWRONGREFERENCE remains?
         'NM_000277.1:c.838_842+3del8' => array(
             'warnings' => array(
-                'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "8" to "N[8]".',
+                'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "8" to "N[8]".',
                 'WSUFFIXGIVEN' => 'Nothing should follow "del".',
             ),
             'errors' => array(


### PR DESCRIPTION
### Release v2
- Make the `library_version` definition version-specific. That way, the old API versions will keep the same library version, so that the library version will really represent the `checkHGVS()` functionality.
- Add the HGVS syntax checker submodule, and enable settings:
  - Allow only for variant input (reject reference sequences, etc);
  - Allow for missing reference sequences.
- Use `getInfo()` directly; its default output is already very informative.
- Update the messages from the library a bit. We're a little more informative, and we don't want to throw errors or warnings when stuff isn't supported.
- Add the v2 of the checkHGVS schema JSON output.
- Add the v2 of the swagger JSON.
- Update the `checkHGVS()` output example in the OpenAPI specs.
- Make the Swagger JSON files version-specific. The Swagger UI doesn't let us switch between JSON specs when we switch versions, as we have currently defined versions. The alternative would be to put everything in one Swagger JSON file, and list all endpoints in one list, e.g., `/v1/checkHGVS`, `/v1/hello`, `/v2/checkHGVS`, `/v2/hello`, but I think that makes little sense. So, fixate the versions in our JSON specs to one version only.
- Make sure the Swagger UI works both online and in our testing environment.
- Define the two separate JSON files in the Swagger UI. That way, it generates a menu in the top bar where we can switch between versions of the API. By default, Swagger shows v2 now.

### Also
- Fix the v1 tests that failed due to library updates. We shouldn't really test the libraries in this repo. The libraries have tests themselves. Of course, the v1 API implementation created confidence values that weren't part of the libraries, so this needed to be tested. But it's better not to do this for v2, as all the functionality for v2 is in the library itself.
- Add a very basic test for the v2 API.
- Improve the info on versions in the README and link to the v1 docs.
- Update the links and the API output in the README to v2.
- Update the README text to explain the v2 API output.
- Update the `.gitignore`.