### PR TITLE
Update the HGVS library and add some fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
         }
     ],
     "versions": {
-        "library_version": "2025-02-14",
+        "library_date": "2025-03-26",
+        "library_version": "0.4.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.1"
+                "maximum": "21.1.2"
             },
-            "output": "21.1.1"
+            "output": "21.1.2"
         }
     }
 }
@@ -161,11 +162,12 @@ This may be corrected in a later version of the API.
 
 The `versions` object collects all relevant versions related to the library that
  powers this API.
-The `library_version` shows the date the internal libraries that interpret
- variant descriptions and provide feedback and possible corrections, were
+The `library_date` shows the date the internal library that interprets
+ variant descriptions and provides feedback and possible corrections, was
  updated.
-Such an update will not create a new API version, as the API version defines
- the behaviour of the API and its output.
+The `library_version` shows the current version of this library.
+An update to this library will not create a new API version,
+ as the API version defines the behaviour of the API and its output.
 The `HGVS_nomenclature_versions` object shows supported HGVS nomenclature
  versions for input (minimum, maximum) and for output.
 
@@ -207,13 +209,14 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
         }
     ],
     "versions": {
-        "library_version": "2025-02-14",
+        "library_date": "2025-03-26",
+        "library_version": "0.4.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.1"
+                "maximum": "21.1.2"
             },
-            "output": "21.1.1"
+            "output": "21.1.2"
         }
     }
 }
@@ -316,13 +319,14 @@ https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
         }
     ],
     "versions": {
-        "library_version": "2025-02-14",
+        "library_date": "2025-03-26",
+        "library_version": "0.4.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.1"
+                "maximum": "21.1.2"
             },
-            "output": "21.1.1"
+            "output": "21.1.2"
         }
     }
 }

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -315,6 +315,19 @@ class LOVD_API_checkHGVS
                     'need a reference sequence to be fully informative and HGVS-compliant.';
             }
 
+            // Don't double-complain about not having a variant when we already complain in a similar way.
+            if (isset($aVariant['errors']['EFAIL'])) {
+                unset($aVariant['errors']['EVARIANTREQUIRED']);
+            } elseif (isset($aVariant['errors']['EVARIANTREQUIRED']) && isset($aVariant['warnings']['WVCF'])) {
+                unset($aVariant['errors']['EVARIANTREQUIRED']);
+                // If there are no more errors left, fix the corrected values.
+                if (!count($aVariant['errors'])) {
+                    foreach ($aVariant['corrected_values'] as $sCorrection => $nConfidence) {
+                        $aVariant['corrected_values'][$sCorrection] = ($nConfidence * 10);
+                    }
+                }
+            }
+
             $this->API->aResponse['data'][] = $aResponse;
         }
         return true;

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,8 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2025-02-18
- * For LOVD    : 3.0-29
+ * Modified    : 2025-03-26
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -650,10 +649,15 @@ class LOVD_API_checkHGVS
             'type' => 'object',
             'additionalProperties' => false,
             'properties' => array(
-                'library_version' => array(
+                'library_date' => array(
                     'description' => 'The date that the library that powers this API, has been updated.',
                     'type' => 'string',
                     'pattern' => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+                ),
+                'library_version' => array(
+                    'description' => 'The version of the library that powers this API.',
+                    'type' => 'string',
+                    'pattern' => '^[0-9]+\.[0-9]+\.[0-9]+$',
                 ),
                 'HGVS_nomenclature_versions' => array(
                     'description' => 'The HGVS nomenclature versions supported by this library.',

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -296,11 +296,14 @@ class LOVD_API_checkHGVS
             if (isset($aResponse['errors']['ENOTSUPPORTED'])) {
                 // Catch and convert ENOTSUPPORTED.
                 // We don't actually know whether this is HGVS compliant or not.
+                if ($aResponse['valid']) {
+                    $aResponse['valid'] = null;
+                }
                 // The library allows for ENOTSUPPORTED, and flags it as valid.
                 $aResponse['messages']['INOTSUPPORTED'] = 'This variant description contains unsupported syntax.' .
                     ' Although we aim to support all of the HGVS nomenclature rules,' .
                     ' some complex variants are not fully implemented yet in our syntax checker.' .
-                    ' We invite you to submit your variant description here, so we can have a look: https://github.com/LOVDnl/api.lovd.nl/issues.';
+                    ' We invite you to submit your variant description here, so we can have a look: https://github.com/LOVDnl/HGVS-syntax-checker/issues.';
                 // And remove the ENOTSUPPORTED.
                 unset($aResponse['errors']['ENOTSUPPORTED']);
             }

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -4,8 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-24
- * Modified    : 2025-02-19         // When modified, also change info->version.
- * For LOVD    : 3.0-29
+ * Modified    : 2025-03-26         // When modified, also change info->version.
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -359,13 +358,14 @@ class LOVD_API_OpenAPISpecs
             )
         );
         $aResponse['components']['responses']['200_checkHGVS']['content']['application/json']['example']['versions'] = array(
-            'library_version' => '2025-02-14',
+            'library_date' => '2025-03-26',
+            'library_version' => '0.4.2',
             'HGVS_nomenclature_versions' => array(
                 'input' => array(
                     'minimum' => '15.11',
-                    'maximum' => '21.1.1'
+                    'maximum' => '21.1.2'
                 ),
-                'output' => '21.1.1'
+                'output' => '21.1.2'
             ),
         );
 


### PR DESCRIPTION
### Update the HGVS library and add some fixes.
- Update the HGVS library and update all related documentation. The HGVS library now uses semantic versioning as well as a date showing the day the library got updated last. Since the output changed, updated all docs with this new format. Since the API isn't used in production yet, we can make this change without releasing a new API version.
- Improve handling `ENOTSUPPORTED`. We don't know if it's valid or not, so set that to null, undefined. Also, update the message to point to the HGVS library repo.
- Sync some logic with the HGVS web interface. The HGVS web interface improved some of the output. When completely invalid input is given, don't complain about a variant being required as we already complain about not understanding the input. When providing VCF input, remove `EVARIANTREQUIRED` and fix the confidence values.