### PR TITLE
Update the HGVS library and fix the schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,17 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
         }
     ],
     "versions": {
-        "library_date": "2025-03-26",
-        "library_version": "0.4.2",
+        "library_date": "2025-07-08",
+        "library_version": "0.5.0",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.2"
+                "maximum": "21.1.3"
             },
-            "output": "21.1.2"
+            "output": "21.1.3"
+        },
+        "caches": {
+            "genes": "2025-07-08"
         }
     }
 }
@@ -170,6 +173,7 @@ An update to this library will not create a new API version,
  as the API version defines the behaviour of the API and its output.
 The `HGVS_nomenclature_versions` object shows supported HGVS nomenclature
  versions for input (minimum, maximum) and for output.
+The `caches` object shows the date that the gene cache have been updated.
 
 ```
 https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
@@ -209,14 +213,17 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
         }
     ],
     "versions": {
-        "library_date": "2025-03-26",
-        "library_version": "0.4.2",
+        "library_date": "2025-07-08",
+        "library_version": "0.5.0",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.2"
+                "maximum": "21.1.3"
             },
-            "output": "21.1.2"
+            "output": "21.1.3"
+        },
+        "caches": {
+            "genes": "2025-07-08"
         }
     }
 }
@@ -319,14 +326,17 @@ https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
         }
     ],
     "versions": {
-        "library_date": "2025-03-26",
-        "library_version": "0.4.2",
+        "library_date": "2025-07-08",
+        "library_version": "0.5.0",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
-                "maximum": "21.1.2"
+                "maximum": "21.1.3"
             },
-            "output": "21.1.2"
+            "output": "21.1.3"
+        },
+        "caches": {
+            "genes": "2025-07-08"
         }
     }
 }

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -627,14 +627,22 @@ class LOVD_API_checkHGVS
                     ),
                     'corrected_values' => array(
                         'description' => 'One or more corrected variant descriptions, given with a confidence score. The given corrections are not necessarily different from the input.',
-                        'type' => 'object',
-                        'additionalProperties' => false,
-                        'patternProperties' => array(
-                            '^.+$' => array(
-                                'description' => 'The confidence score for this correction, ranging from near zero to 100%.',
-                                'type' => 'number',
-                                'exclusiveMinimum' => 0,
-                                'maximum' => 1,
+                        'oneOf' => array(
+                            array(
+                                'type' => 'array',
+                                'maxContains' => 0,
+                            ),
+                            array(
+                                'type' => 'object',
+                                'additionalProperties' => false,
+                                'patternProperties' => array(
+                                    '^.+$' => array(
+                                        'description' => 'The confidence score for this correction, ranging from near zero to 100%.',
+                                        'type' => 'number',
+                                        'exclusiveMinimum' => 0,
+                                        'maximum' => 1,
+                                    ),
+                                ),
                             ),
                         ),
                     ),

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -735,6 +735,17 @@ class LOVD_API_checkHGVS
                         ),
                     ),
                 ),
+                'caches' => array(
+                    'description' => 'The dates that caches for this library have been updated.',
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => array(
+                        'genes' => array(
+                            'type' => 'string',
+                            'pattern' => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+                        ),
+                    ),
+                ),
             ),
         );
         $aReturn['required'][4] = 'versions';

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -691,6 +691,26 @@ class LOVD_API_checkHGVS
             'range',
         );
 
+        // Adjust; we now also support gene information.
+        $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1] = array(
+            'oneOf' => array(
+                $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1],
+                array(
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => array(
+                        'hgnc_id' => array(
+                            'description' => 'The HGNC ID of the given gene, if identified.',
+                            'type' => 'integer',
+                        ),
+                    ),
+                    'required' => array(
+                        'hgnc_id',
+                    ),
+                ),
+            ),
+        );
+
         // Replace "library_version" with "versions".
         unset($aReturn['properties']['library_version']);
         $aReturn['properties']['versions'] = array(

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2025-03-26
+ * Modified    : 2025-07-09
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -199,7 +199,9 @@ class LOVD_API_checkHGVS
                 // Not HGVS-compliant, and not unsupported, so let's see if we can suggest something better.
                 $sFixedVariant = lovd_fixHGVS($sVariant);
                 $aFixedVariantInfo = lovd_getVariantInfo($sFixedVariant, false);
-                unset($aFixedVariantInfo['warnings']['WNOTSUPPORTED']);
+                if ($aFixedVariantInfo) {
+                    unset($aFixedVariantInfo['warnings']['WNOTSUPPORTED']);
+                }
 
                 // We normally don't show non-HGVS compliant suggestions. Exception 1;
                 // Treat the result as HGVS compliant (i.e., accept suggestion and show)

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -588,11 +588,25 @@ class LOVD_API_checkHGVS
                     ),
                     'identified_as' => array(
                         'description' => 'A short description of what the library identified the input as. This field is meant to be parsed, if needed.',
-                        'type' => 'string',
+                        'oneOf' => array(
+                            array(
+                                'type' => 'string',
+                            ),
+                            array(
+                                'const' => false,
+                            ),
+                        ),
                     ),
                     'identified_as_formatted' => array(
                         'description' => 'A formatted version of the "identified as" field. This field is meant to be displayed to the user, if needed.',
-                        'type' => 'string',
+                        'oneOf' => array(
+                            array(
+                                'type' => 'string',
+                            ),
+                            array(
+                                'const' => false,
+                            ),
+                        ),
                     ),
                     'valid' => array(
                         'description' => 'Whether the input was considered to be a valid variant description.',

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -615,7 +615,16 @@ class LOVD_API_checkHGVS
                     'messages' => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['messages'],
                     'warnings' => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['warnings'],
                     'errors'   => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['errors'],
-                    'data'     => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['data'],
+                    'data'     => array(
+                        'description' => $aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['data']['description'],
+                        'oneOf' => array(
+                            array(
+                                'type' => 'array',
+                                'maxContains' => 0,
+                            ),
+                            array_diff_key($aReturn['properties']['data']['oneOf'][1]['patternProperties']['^.+$']['properties']['data'], array_flip(array('description'))),
+                        ),
+                    ),
                     'corrected_values' => array(
                         'description' => 'One or more corrected variant descriptions, given with a confidence score. The given corrections are not necessarily different from the input.',
                         'type' => 'object',
@@ -645,7 +654,7 @@ class LOVD_API_checkHGVS
         );
 
         // OK, actually, "data" is not completely the same.
-        $aReturn['properties']['data']['items']['properties']['data']['properties']['type']['enum'] = array(
+        $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1]['properties']['type']['enum'] = array(
             '=',
             '>',
             '?',
@@ -666,9 +675,9 @@ class LOVD_API_checkHGVS
         );
 
         // Remove "suggested_correction".
-        unset($aReturn['properties']['data']['items']['properties']['data']['properties']['suggested_correction']);
+        unset($aReturn['properties']['data']['items']['properties']['data']['oneOf'][1]['properties']['suggested_correction']);
         // Also "type" isn't required anymore, so just rebuild the "required" array.
-        $aReturn['properties']['data']['items']['properties']['data']['required'] = array(
+        $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1]['required'] = array(
             'position_start',
             'position_end',
             'range',

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -367,6 +367,9 @@ class LOVD_API_OpenAPISpecs
                 ),
                 'output' => '21.1.2'
             ),
+            'caches' => array(
+                'genes' => '2025-06-17',
+            ),
         );
 
         return $aResponse;


### PR DESCRIPTION
### Update the HGVS library and fix the schemas
- Update the HGVS library to 0.5.0.
- Fix a warning in the v1 checkHGVS endpoint. When a variant can't be fixed, the result of the fix is false as well. You can't unset a warning in false; it's not an array.
- Several fixes to the schemas.
  - The `identified_as` fields can be false.
  - The `data` array can be empty.
  - `corrected_values` can be empty.
  - Update the definitions for the versions array. We now have a `caches` key with the date that the gene cache has been updated.
  - The library now also recognizes genes, which have different output.
- Update the example outputs in the README.