### PR TITLE
Add the checkGene endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,56 @@ Below is the updated manual for version 2.
 
 
 
+## General information about the output
+Besides the `version` key, all outputs also show the `messages`, `warnings`,
+ `errors`, and `data` keys.
+Note that the first `messages`, `warnings`, and `errors` arrays describe the
+ request as a whole, while those possibly found within the `data` object are
+ specific for the given query.
+Errors are, in general, non-recoverable.
+Warnings are, in general, recoverable and repairable.
+Messages are simply for your information.
+Due to limitations of our implementation of PHP's `json_encode()`, these objects
+ will be arrays when empty.
+This may be corrected in a later version of the API.
+The `data` array contains the output of your query.
+This is empty when the query did not produce any output or if there was a
+ problem with processing your query.
+Otherwise, `data` holds an array of query results; one result per query.
+
+All `messages`, `warnings`, and `errors` within the result objects in the `data`
+ array return a code, e.g., `WWRONGTYPE`, as well as a human-readable text.
+Codes allow you to interpret the meaning of the feedback without the need to
+ read it or rely on the stability of the verbose strings.
+We stress that between different library versions, the strings may be updated.
+Therefore, use the stable codes to recognize the type of feedback given.
+The text is meant for human users, and can be used by you for this purpose.
+
+The first letter of each code describes the type of reply;
+ `I` for information (messages), `W` for warning, and `E` for error.
+This allows you to group these objects if needed, while still being clear on the
+ origin of each entry.
+Note also that errors and warnings exist with similar codes, e.g., `EWRONGTYPE`
+ and `WWRONGTYPE`.
+
+API endpoints that use the
+ [LOVD HGVS library](https://github.com/LOVDnl/HGVS-syntax-checker)
+ also return a `versions` key in the main result object.
+The `versions` object collects all relevant versions related to the library.
+The `library_date` shows the date the internal library that interprets
+ variant descriptions and provides feedback and possible corrections, was
+ updated.
+The `library_version` shows the current version of this library.
+An update to this library will not create a new API version,
+ as the API version defines the behaviour of the API and its output.
+The `HGVS_nomenclature_versions` object shows supported HGVS nomenclature
+ versions for input (minimum, maximum) and for output.
+The `caches` object shows the date that the gene cache has been updated.
+
+
+
+
+
 ## API endpoints
 ### /hello
 Use this method just to see if the API is alive or not.
@@ -153,27 +203,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
 }
 ```
 
-Note that the first `messages`, `warnings`, and `errors` arrays describe the
- request as a whole, while those within the `data` object are specific for the
- given variant.
-Errors are, in general, non-recoverable.
-Warnings are, in general, recoverable and easily repairable.
-Messages are simply for your information.
-Due to limitations of our implementation of PHP's `json_encode()`, these objects
- will be arrays when empty.
-This may be corrected in a later version of the API.
-
-The `versions` object collects all relevant versions related to the library that
- powers this API.
-The `library_date` shows the date the internal library that interprets
- variant descriptions and provides feedback and possible corrections, was
- updated.
-The `library_version` shows the current version of this library.
-An update to this library will not create a new API version,
- as the API version defines the behaviour of the API and its output.
-The `HGVS_nomenclature_versions` object shows supported HGVS nomenclature
- versions for input (minimum, maximum) and for output.
-The `caches` object shows the date that the gene cache have been updated.
+Problems are automatically fixed if possible:
 
 ```
 https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
@@ -229,20 +259,9 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
 }
 ```
 
-All `messages`, `warnings`, and `errors` within the `data` object return a code,
- e.g., `WWRONGTYPE`, as well as a human-readable text.
-Codes allow you to interpret the meaning of the feedback without the need to
- read it or rely on the stability of the verbose strings.
-We stress that between different library versions, the strings may be updated.
-Therefore, use the stable codes to recognize the type of feedback given.
-The text is meant for human users, and can be used by you for this purpose.
-
-The first letter of each code describes the type of reply;
- `I` for information (messages), `W` for warning, and `E` for error.
-This allows you to group these objects if needed, while still being clear on the
- origin of each entry.
-Note also that errors and warnings exist with similar codes, e.g., `EWRONGTYPE`
- and `WWRONGTYPE`. 
+Information about `messages`, `warnings`, and `errors` within the `data` object
+ is explained under
+ "[General information about the output](#general-information-about-the-output)".
 
 When requesting a variant that contains incorrect syntax, the API will attempt
  to repair your description.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,91 @@ The `corrected_values` object will list the official gene symbol and the
  associated confidence score between near-zero and one, indicating how sure the
  library is that its suggestion represents the gene you meant to describe.
 
+##### Multiple queries
+To submit multiple queries in one request, present them as a
+ JSON array, added to the URL using the standard URL encoding.
+For instance, to submit `BRCA1` and `HGNC:1101` for validation,
+ you should construct an JSON array like so:
+
+```json
+["BRCA1","HGNC:1101"]
+```
+
+which is then URL encoded to:
+
+```
+%5B%22BRCA1%22%2C%22HGNC%3A1101%22%5D
+```
+
+We decided on this structure for compatibility with the `checkHGVS` endpoint.
+Lots of possible single character separators are now,
+ or maybe in the future, used as a part of the HGVS nomenclature.
+E.g., the forward slash is used to indicate mosaicism and chimerism, and the
+ pipe is used for non-sequence related changes such as loss of methylation.
+
+```
+http://localhost/git/api.lovd.nl/src/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A1101%22%5D
+```
+
+```json
+{
+    "version": 2,
+    "messages": [
+        "Successfully received 2 queries."
+    ],
+    "warnings": [],
+    "errors": [],
+    "data": [
+        {
+            "input": "BRCA1",
+            "identified_as": "gene_symbol",
+            "identified_as_formatted": "gene symbol",
+            "valid": true,
+            "messages": [],
+            "warnings": [],
+            "errors": [],
+            "data": {
+                "hgnc_id": 1100
+            },
+            "corrected_values": {
+                "BRCA1": 1
+            }
+        },
+        {
+            "input": "HGNC:1101",
+            "identified_as": "HGNC_ID",
+            "identified_as_formatted": "HGNC ID",
+            "valid": true,
+            "messages": {
+                "ISYMBOLFOUND": "The HGNC ID 1101 points to gene symbol \"BRCA2\"."
+            },
+            "warnings": [],
+            "errors": [],
+            "data": {
+                "hgnc_id": "1101"
+            },
+            "corrected_values": {
+                "BRCA2": 1
+            }
+        }
+    ],
+    "versions": {
+        "library_date": "2025-07-08",
+        "library_version": "0.5.0",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.3"
+            },
+            "output": "21.1.3"
+        },
+        "caches": {
+            "genes": "2025-07-08"
+        }
+    }
+}
+```
+
 
 
 ### /checkHGVS

--- a/README.md
+++ b/README.md
@@ -136,6 +136,79 @@ This API doesn't support any input.
 
 
 
+### /checkGene (v2 only)
+Validate one or more gene symbols or identifiers using this API.
+It recognizes discontinued gene symbols and aliases.
+The API will return the HGNC ID and the official gene symbol.
+
+#### API possibilities
+The JSON schema for the API output is encoded in the API itself and can be
+ accessed by opening the URL `/checkGene/schema.json`.
+If you want to retrieve the schema for a certain version,
+ use `/v2/checkGene/schema.json`.
+As an example, see https://api.lovd.nl/v2/checkGene/schema.json.
+
+##### Single query
+To submit a single query, e.g., `IVD`, simply add it to the URL.
+If special characters are used, follow the requirements for URL encoding.
+
+```
+https://api.lovd.nl/v2/checkGene/IVD
+```
+
+```json
+{
+    "version": 2,
+    "messages": [
+        "Successfully received 1 query."
+    ],
+    "warnings": [],
+    "errors": [],
+    "data": [
+        {
+            "input": "IVD",
+            "identified_as": "gene_symbol",
+            "identified_as_formatted": "gene symbol",
+            "valid": true,
+            "messages": [],
+            "warnings": [],
+            "errors": [],
+            "data": {
+                "hgnc_id": 6186
+            },
+            "corrected_values": {
+                "IVD": 1
+            }
+        }
+    ],
+    "versions": {
+        "library_date": "2025-07-08",
+        "library_version": "0.5.0",
+        "HGVS_nomenclature_versions": {
+            "input": {
+                "minimum": "15.11",
+                "maximum": "21.1.3"
+            },
+            "output": "21.1.3"
+        },
+        "caches": {
+            "genes": "2025-07-08"
+        }
+    }
+}
+```
+
+The `identified_as` and `identified_as_formatted` fields show whether your
+ query was identified as a gene symbol or an HGNC ID.
+The `valid` boolean shows whether your input was valid; deprecated gene symbols
+ or aliases will return `false` here.
+The `hgnc_id` field will list the HGNC ID for the given gene.
+The `corrected_values` object will list the official gene symbol and the
+ associated confidence score between near-zero and one, indicating how sure the
+ library is that its suggestion represents the gene you meant to describe.
+
+
+
 ### /checkHGVS
 Validate a single variant description or
  a set of variant descriptions using this API.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The `caches` object shows the date that the gene cache has been updated.
 ### /hello
 Use this method just to see if the API is alive or not.
 If it is, it will return an HTTP 200 status with the following output.
+
 ```json
 {
     "version": 2,
@@ -151,9 +152,11 @@ As an example, see https://api.lovd.nl/v2/checkHGVS/schema.json.
 ##### Single variant input
 To submit a single variant description, e.g., `NM_002225.3:c.157C>T`, simply add
  it to the URL following the requirements for URL encoding:
+
 ```
 https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
 ```
+
 ```json
 {
     "version": 2,
@@ -208,6 +211,7 @@ Problems are automatically fixed if possible:
 ```
 https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
 ```
+
 ```json
 {
     "version": 2,
@@ -275,10 +279,13 @@ To submit multiple variant descriptions in one request, present them as a
  JSON array, added to the URL using the standard URL encoding.
 For instance, to submit `c.157C>T` and `g.40699840C>T` for validation,
  you should construct an JSON array like so:
+
 ```json
 ["c.157C>T","g.40699840C>T"]
 ```
+
 which is then URL encoded to:
+
 ```
 %5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
 ```
@@ -287,9 +294,11 @@ We decided on this structure since lots of possible single character separators
  are now, or maybe in the future, used as a part of the HGVS nomenclature.
 E.g., the forward slash is used to indicate mosaicism and chimerism, and the
  pipe is used for non-sequence related changes such as loss of methylation.
+
 ```
 https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
 ```
+
 ```json
 {
     "version": 2,

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -34,6 +34,30 @@ if (!defined('ROOT_PATH')) {
 
 
 
+class LOVD_API_checkGene extends LOVD_API_checkHGVS
+{
+    // This class defines the LOVD API object handling the checkGene API.
+    // This class extends the LOVD_API_checkHGVS class, since they use the same internal tools.
+
+    public function processGET ($aURLElements, $bReturnBody)
+    {
+        // Handle GET and HEAD requests for the checkGene API, based on the checkHGVS API.
+        $b = parent::processGET($aURLElements, $bReturnBody);
+
+        // If we received no input, change the output message.
+        if (!empty($this->API->aResponse['errors'])
+            && str_ends_with($this->API->aResponse['errors'][0], 'Did you submit a variant?')) {
+            $this->API->aResponse['errors'][0] = str_replace('variant?', 'gene?', $this->API->aResponse['errors'][0]);
+        }
+
+        return $b;
+    }
+}
+
+
+
+
+
 class LOVD_API_checkHGVS
 {
     // This class defines the LOVD API object handling the checkHGVS API.

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -80,6 +80,33 @@ class LOVD_API_checkGene extends LOVD_API_checkHGVS
         }
         return true;
     }
+
+
+
+
+
+    public function v2_getJSONSchema ()
+    {
+        // Return the JSON Schema for the v2 checkGene response format.
+        // Takes the basics from the checkHGVS output, then makes changes.
+        $aReturn = parent::v2_getJSONSchema();
+
+        // Fix the title and description.
+        $aReturn['title'] = str_replace('checkHGVS', 'checkGene', $aReturn['title']);
+        $aReturn['description'] = str_replace('checkHGVS', 'checkGene', $aReturn['description']);
+
+        // Fix the data specs.
+        $aReturn['properties']['data']['items']['properties']['valid']['description'] = str_replace(
+            'variant description',
+            'gene symbol or identifier',
+            $aReturn['properties']['data']['items']['properties']['valid']['description']
+        );
+        $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1] = $aReturn['properties']['data']['items']['properties']['data']['oneOf'][1]['oneOf'][1];
+        $aReturn['properties']['data']['items']['properties']['corrected_values']['description'] =
+            'The valid gene symbol for the given gene, given with a confidence score. The given value is not necessarily different from the input.';
+
+        return $aReturn;
+    }
 }
 
 

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -52,6 +52,34 @@ class LOVD_API_checkGene extends LOVD_API_checkHGVS
 
         return $b;
     }
+
+
+
+
+
+    public function v2_checkGene ($aInput)
+    {
+        // Run the validations, using the new HGVS class approach.
+        if (!file_exists(ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php')) {
+            // This API requires the HGVS.php class file from https://github.com/LOVDnl/HGVS-syntax-checker.
+            // If not found, double-check if you ran `git submodule init && git submodule update`.
+            // This repository will not duplicate the code.
+            $this->API->aResponse['errors'][] = 'Could not load the HGVS library.';
+            return false;
+        }
+
+        require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
+        $this->API->aResponse['versions'] = HGVS::getVersions();
+
+        $nInput = count($aInput);
+        $this->API->aResponse['messages'][] = "Successfully received $nInput quer" . ($nInput == 1? "y." : "ies.");
+
+        // Now actually handle the request.
+        foreach ($aInput as $sInput) {
+            $this->API->aResponse['data'][] = HGVS_Gene::check($sInput)->getInfo();
+        }
+        return true;
+    }
 }
 
 

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2025-07-09
+ * Modified    : 2025-07-10
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -38,7 +38,7 @@ class LOVD_API_checkHGVS
 {
     // This class defines the LOVD API object handling the checkHGVS API.
 
-    private $API;                     // The API object.
+    protected $API;                   // The API object.
 
 
 
@@ -116,7 +116,7 @@ class LOVD_API_checkHGVS
 
 
         // Check the current version and run that method.
-        $sMethod = 'v' . $this->API->nVersion . '_checkHGVS';
+        $sMethod = str_replace('LOVD_API', 'v' . $this->API->nVersion, get_class($this));
         return call_user_func(array($this, $sMethod), $aInput);
     }
 

--- a/src/class/api.openapi-specs.php
+++ b/src/class/api.openapi-specs.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-24
- * Modified    : 2025-03-26         // When modified, also change info->version.
+ * Modified    : 2025-07-10         // When modified, also change info->version.
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -371,6 +371,116 @@ class LOVD_API_OpenAPISpecs
                 'genes' => '2025-06-17',
             ),
         );
+
+        // Add the checkGene endpoint.
+        $aResponse['paths'] = array_merge(
+            array(
+                '/checkGene/{gene}' => array(
+                    'get' => array(
+                        'tags' => array(
+                            'Public LOVD API endpoints'
+                        ),
+                        'summary' => 'Method to validate gene symbols and HGNC IDs.',
+                        'description' => 'Validate one or more gene symbols or HGNC IDs using this API. It will return the HGNC ID and the official gene symbol if a match has been found.',
+                        'operationId' => 'getCheckGene',
+                        'parameters' => array(
+                            array(
+                                'name' => 'gene',
+                                'in' => 'path',
+                                'description' => 'A single term or a JSON-formatted list of terms.',
+                                'required' => true,
+                                'schema' => array(
+                                    'oneOf' => array(
+                                        // These schemas can also contain examples, but Swagger doesn't show them.
+                                        // So pulled out the examples, and stored them separately.
+                                        array(
+                                            'title' => 'A single gene symbol or HGNC ID.',
+                                            'type' => 'string',
+                                        ),
+                                        array(
+                                            'title' => 'A JSON-formatted list of gene symbols or HGNC IDs.',
+                                            'type' => 'string',
+                                            'pattern' => '^\[".+"\]$',
+                                        ),
+                                    ),
+                                ),
+                                'examples' => array(
+                                    // The key name doesn't seem to matter.
+                                    'single' => array(
+                                        'summary' => 'A single term.',
+                                        'value' => 'IVD',
+                                    ),
+                                    'multiple' => array(
+                                        'summary' => 'A JSON-formatted list of terms.',
+                                        'value' => '["IVD","HGNC:6186"]',
+                                    ),
+                                ),
+                            ),
+                        ),
+                        'responses' => array(
+                            '200' => array(
+                                '$ref' => '#/components/responses/200_checkGene',
+                            ),
+                            '4XX' => array(
+                                '$ref' => '#/components/responses/4XX_checkGene',
+                            ),
+                            '500' => array(
+                                '$ref' => '#/components/responses/500_checkGene',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            $aResponse['paths']
+        );
+
+        // Provide the available responses.
+        $aResponse['components']['responses'] = array_merge(
+            array(
+                '200_checkGene' => array(
+                    'description' => 'A result of a successfully processed query or list of queries. This does not mean that the input was valid.',
+                    'content' => array(
+                        'application/json' => array(
+                            'schema' => array(
+                                '$ref' => 'checkGene/schema.json',
+                            ),
+                            'example' => array(
+                                'version' => $this->API->nVersion,
+                                'messages' => array(
+                                    'Successfully received 1 query.',
+                                ),
+                                'warnings' => array(),
+                                'errors' => array(),
+                                'data' => array(
+                                    array(
+                                        'input' => 'IVD',
+                                        'identified_as' => 'gene_symbol',
+                                        'identified_as_formatted' => 'gene symbol',
+                                        'valid' => true,
+                                        'messages' => array(),
+                                        'warnings' => array(),
+                                        'errors' => array(),
+                                        'data' => array(
+                                            'hgnc_id' => 6186,
+                                        ),
+                                        'corrected_values' => array(
+                                            'IVD' => 1
+                                        ),
+                                    ),
+                                ),
+                                'versions' => $aResponse['components']['responses']['200_checkHGVS']['content']['application/json']['example']['versions'],
+                            ),
+                        ),
+                    ),
+                ),
+                '4XX_checkGene' => $aResponse['components']['responses']['4XX_checkHGVS'],
+                '500_checkGene' => $aResponse['components']['responses']['500_checkHGVS'],
+            ),
+            $aResponse['components']['responses'],
+        );
+        $aResponse['components']['responses']['4XX_checkGene']['content']['application/json']['schema']['$ref'] = 'checkGene/schema.json';
+        $aResponse['components']['responses']['4XX_checkGene']['content']['application/json']['example']['errors'][0] = 'Could not parse the given request. Did you submit a gene?';
+        $aResponse['components']['responses']['500_checkGene']['content']['application/json']['schema']['$ref'] = 'checkGene/schema.json';
 
         return $aResponse;
     }

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -5,8 +5,7 @@
  * Adapted from /src/class/api.php in the LOVD3 project.
  *
  * Created     : 2022-08-08
- * Modified    : 2025-02-18
- * For LOVD    : 3.0-30
+ * Modified    : 2025-07-10
  *
  * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -61,6 +60,7 @@ class LOVD_API
 
     // Currently supported resources (resource => array(methods)):
     private $aResourcesSupported = array(
+        'checkGene' => array('GET', 'HEAD'),
         'checkHGVS' => array('GET', 'HEAD'),
         'hello' => array('GET', 'HEAD', 'POST'),
         'openapi.json' => array('GET', 'HEAD'),
@@ -420,7 +420,10 @@ class LOVD_API
         // Processes the GET calls to the API.
 
         // Currently handling the checkHGVS API from api.lovd.nl, and the 'ga4gh' resource, for GA4GH Data Connect.
-        if ($this->sResource == 'checkHGVS') {
+        if ($this->sResource == 'checkGene') {
+            require_once 'class/api.checkHGVS.php';
+            $o = new LOVD_API_checkGene($this);
+        } elseif ($this->sResource == 'checkHGVS') {
             require_once 'class/api.checkHGVS.php';
             $o = new LOVD_API_checkHGVS($this);
         } elseif ($this->sResource == 'ga4gh') {


### PR DESCRIPTION
### Add the checkGene endpoint
- Prepare the `checkHGVS` class to be inherited.
- Add the basics of the `checkGene` class. Re-use `checkHGVS`'s output of `processGET()`, but manipulate the output a bit if needed.
- Add the method that checks the input; it needs very little code.
- Add `checkGene`'s JSON schema. This method is based on its parent's JSON schema, but adjusts the output to match this endpoint's schema.
- Enable the `checkGene` endpoint.
- Describe the `checkGene` endpoint in Swagger.
- Document the `checkGene` endpoint.
  - Move more general information to the top of the page.
  - Add more whitespace to enhance readability.
  - Add the basics on the `checkGene` endpoint.
  - Document the multiple queries for the `checkGene` endpoint.