### PR TITLE
Update the HGVS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ https://api.lovd.nl/v2/checkGene/IVD
         }
     ],
     "versions": {
-        "library_date": "2025-07-08",
-        "library_version": "0.5.0",
+        "library_date": "2026-04-14",
+        "library_version": "1.1.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -192,7 +192,8 @@ https://api.lovd.nl/v2/checkGene/IVD
             "output": "21.1.3"
         },
         "caches": {
-            "genes": "2025-07-08"
+            "genes": "2026-04-14",
+            "transcripts": "2026-04-14"
         }
     }
 }
@@ -230,7 +231,7 @@ E.g., the forward slash is used to indicate mosaicism and chimerism, and the
  pipe is used for non-sequence related changes such as loss of methylation.
 
 ```
-http://localhost/git/api.lovd.nl/src/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A1101%22%5D
+https://api.lovd.nl/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A1101%22%5D
 ```
 
 ```json
@@ -268,7 +269,7 @@ http://localhost/git/api.lovd.nl/src/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A110
             "warnings": [],
             "errors": [],
             "data": {
-                "hgnc_id": "1101"
+                "hgnc_id": 1101
             },
             "corrected_values": {
                 "BRCA2": 1
@@ -276,8 +277,8 @@ http://localhost/git/api.lovd.nl/src/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A110
         }
     ],
     "versions": {
-        "library_date": "2025-07-08",
-        "library_version": "0.5.0",
+        "library_date": "2026-04-14",
+        "library_version": "1.1.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -286,7 +287,8 @@ http://localhost/git/api.lovd.nl/src/v2/checkGene/%5B%22BRCA1%22%2C%22HGNC%3A110
             "output": "21.1.3"
         },
         "caches": {
-            "genes": "2025-07-08"
+            "genes": "2026-04-14",
+            "transcripts": "2026-04-14"
         }
     }
 }
@@ -335,6 +337,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
             "warnings": [],
             "errors": [],
             "data": {
+                "hgnc_id": 6186,
                 "position_start": 157,
                 "position_end": 157,
                 "position_start_intron": 0,
@@ -348,8 +351,8 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
         }
     ],
     "versions": {
-        "library_date": "2025-07-08",
-        "library_version": "0.5.0",
+        "library_date": "2026-04-14",
+        "library_version": "1.1.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -358,7 +361,8 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
             "output": "21.1.3"
         },
         "caches": {
-            "genes": "2025-07-08"
+            "genes": "2026-04-14",
+            "transcripts": "2026-04-14"
         }
     }
 }
@@ -392,6 +396,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
             },
             "errors": [],
             "data": {
+                "hgnc_id": 6186,
                 "position_start": 157,
                 "position_end": 157,
                 "position_start_intron": 0,
@@ -400,13 +405,13 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
                 "type": "delins"
             },
             "corrected_values": {
-                "NM_002225.3:c.157C>T": 1
+                "NM_002225.5:c.157C>T": 1
             }
         }
     ],
     "versions": {
-        "library_date": "2025-07-08",
-        "library_version": "0.5.0",
+        "library_date": "2026-04-14",
+        "library_version": "1.1.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -415,7 +420,8 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
             "output": "21.1.3"
         },
         "caches": {
-            "genes": "2025-07-08"
+            "genes": "2026-04-14",
+            "transcripts": "2026-04-14"
         }
     }
 }
@@ -512,8 +518,8 @@ https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
         }
     ],
     "versions": {
-        "library_date": "2025-07-08",
-        "library_version": "0.5.0",
+        "library_date": "2026-04-14",
+        "library_version": "1.1.2",
         "HGVS_nomenclature_versions": {
             "input": {
                 "minimum": "15.11",
@@ -522,7 +528,8 @@ https://api.lovd.nl/v2/checkHGVS/%5B%22c.157C%3ET%22%2C%22g.40699840C%3ET%22%5D
             "output": "21.1.3"
         },
         "caches": {
-            "genes": "2025-07-08"
+            "genes": "2026-04-14",
+            "transcripts": "2026-04-14"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ To make sure this doesn't harm your application,
  you can instruct the API to use a fixed version.
 To do so, you must include the API's version in the URL.
 For instance, to always use
- [version 1](https://api.lovd.nl/v1/checkHGVS/NM_002225.3%3Ac.157C%3ET)
+ [version 1](https://api.lovd.nl/v1/checkHGVS/NM_002225.5%3Ac.157C%3ET)
  of the API, even with
- [version 2](https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET)
+ [version 2](https://api.lovd.nl/v2/checkHGVS/NM_002225.5%3Ac.157C%3ET)
  now released, use `/v1/checkHGVS` instead of `/checkHGVS`.
 _When you're not supplying a version number in the URL,
  the API will automatically use the latest version._
@@ -310,11 +310,11 @@ If you want to retrieve the schema for a certain version,
 As an example, see https://api.lovd.nl/v2/checkHGVS/schema.json.
 
 ##### Single variant input
-To submit a single variant description, e.g., `NM_002225.3:c.157C>T`, simply add
+To submit a single variant description, e.g., `NM_002225.5:c.157C>T`, simply add
  it to the URL following the requirements for URL encoding:
 
 ```
-https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
+https://api.lovd.nl/v2/checkHGVS/NM_002225.5%3Ac.157C%3ET
 ```
 
 ```json
@@ -329,7 +329,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
     "errors": [],
     "data": [
         {
-            "input": "NM_002225.3:c.157C>T",
+            "input": "NM_002225.5:c.157C>T",
             "identified_as": "full_variant_DNA",
             "identified_as_formatted": "full variant (DNA)",
             "valid": true,
@@ -346,7 +346,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
                 "type": ">"
             },
             "corrected_values": {
-                "NM_002225.3:c.157C>T": 1
+                "NM_002225.5:c.157C>T": 1
             }
         }
     ],
@@ -371,7 +371,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157C%3ET
 Problems are automatically fixed if possible:
 
 ```
-https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
+https://api.lovd.nl/v2/checkHGVS/NM_002225.5%3Ac.157delCinsT
 ```
 
 ```json
@@ -386,7 +386,7 @@ https://api.lovd.nl/v2/checkHGVS/NM_002225.3%3Ac.157delCinsT
     "errors": [],
     "data": [
         {
-            "input": "NM_002225.3:c.157delCinsT",
+            "input": "NM_002225.5:c.157delCinsT",
             "identified_as": "full_variant_DNA",
             "identified_as_formatted": "full variant (DNA)",
             "valid": false,

--- a/src/class/api.checkHGVS.php
+++ b/src/class/api.checkHGVS.php
@@ -4,9 +4,9 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-08
- * Modified    : 2025-07-10
+ * Modified    : 2026-04-14
  *
- * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -69,14 +69,14 @@ class LOVD_API_checkGene extends LOVD_API_checkHGVS
         }
 
         require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
-        $this->API->aResponse['versions'] = HGVS::getVersions();
+        $this->API->aResponse['versions'] = LOVD\HGVS\HGVS::getVersions();
 
         $nInput = count($aInput);
         $this->API->aResponse['messages'][] = "Successfully received $nInput quer" . ($nInput == 1? "y." : "ies.");
 
         // Now actually handle the request.
         foreach ($aInput as $sInput) {
-            $this->API->aResponse['data'][] = HGVS_Gene::check($sInput)->getInfo();
+            $this->API->aResponse['data'][] = LOVD\HGVS\HGVS_Gene::check($sInput)->getInfo();
         }
         return true;
     }
@@ -358,7 +358,7 @@ class LOVD_API_checkHGVS
         }
 
         require ROOT_PATH . 'libs/HGVS-syntax-checker/HGVS.php';
-        $this->API->aResponse['versions'] = HGVS::getVersions();
+        $this->API->aResponse['versions'] = LOVD\HGVS\HGVS::getVersions();
 
         // v1 used to have a check here for unique input, but since we format the output differently, we don't care.
         $nInput = count($aInput);
@@ -368,7 +368,7 @@ class LOVD_API_checkHGVS
 
         // Now actually handle the request.
         foreach ($aInput as $sVariant) {
-            $aResponse = HGVS::checkVariant($sVariant)->allowMissingReferenceSequence()->getInfo();
+            $aResponse = LOVD\HGVS\HGVS::checkVariant($sVariant)->allowMissingReferenceSequence()->getInfo();
 
             // In case it's set, we don't care about WNOTSUPPORTED. We won't validate anyway,
             //  and this warning is thrown only for HGVS-compliant descriptions.

--- a/tests/checkHGVS.php
+++ b/tests/checkHGVS.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-08-16
- * Modified    : 2025-02-19
+ * Modified    : 2026-04-14
  * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2026 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -1298,14 +1298,18 @@ $aTests = array(
             'identified_as' => 'full_variant_DNA',
             'identified_as_formatted' => 'full variant (DNA)',
             'valid' => false,
+            'messages' => array(
+                'IREFSEQVERSION' => 'Consider updating your use of NM_000277 to a newer version (e.g., NM_000277.3).',
+            ),
             'warnings' => array(
                 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.',
                 'WSUFFIXGIVEN' => 'The deleted sequence is redundant and should be removed.',
             ),
             'errors' => array(
-                'EWRONGREFERENCE' => 'A genomic transcript reference sequence is required to verify intronic positions.',
+                'EWRONGREFERENCE' => 'To verify intronic positions, add a genomic context to the transcript reference sequence.',
             ),
             'data' => array(
+                'hgnc_id' => 8582,
                 'position_start' => 838,
                 'position_end' => 842,
                 'position_start_intron' => 0,
@@ -1458,10 +1462,14 @@ foreach ($aTests[$nVersion] as $aExpectedOutput) {
     }
 
     if (!isset($aOutput['versions'])
-        || array_keys($aOutput['versions']) != ['library_version', 'HGVS_nomenclature_versions']
+        || array_keys($aOutput['versions']) != ['library_date', 'library_version', 'HGVS_nomenclature_versions', 'caches']
+        || !preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $aOutput['versions']['library_date'])
+        || !preg_match('/^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/', $aOutput['versions']['library_version'])
         || array_keys($aOutput['versions']['HGVS_nomenclature_versions']) != ['input', 'output']
         || array_keys($aOutput['versions']['HGVS_nomenclature_versions']['input']) != ['minimum', 'maximum']
-        || !preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $aOutput['versions']['library_version'])) {
+        || array_keys($aOutput['versions']['caches']) != ['genes', 'transcripts']
+        || !preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $aOutput['versions']['caches']['genes'])
+        || !preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $aOutput['versions']['caches']['transcripts'])) {
         // Error...
         $aDifferences[$nTests] = array($nVersion, $sVariant, $aExpectedOutput, $aOutput);
         echo 'E';


### PR DESCRIPTION
### Update the HGVS library
- Update the HGVS library to v1.1.1. With the switch to v1.0.0, the internal workings of the HGVS syntax checker were updated, so we'll need to update the code next.
- Update the HGVS library to v1.1.2 due to a bug in v1.1.1. This bug only showed here, the HGVS tests did not show it. Due to the recent namespace switch in v1.0.0, the flag to allow dynamic properties, `#[AllowDynamicProperties]`, had to be namespaced as well, to become `#[\AllowDynamicProperties]`.
- Update the API code to handle the v1 branch of the HGVS library. Basically, make sure that we use the namespaces.
- Update the tests to align with the latest output.
- Update the JSON outputs in the README to the latest versions.
- Update a transcript version to prevent a warning about its age.
